### PR TITLE
Update security level

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,7 @@ provided with OTP in `<otp>/lib/snmp-<version>/mibs/` and do not need to be
 included. MIB compilation is quite complex: `use Snmp.Mib` (see [Instrumenting MIB below](https://github.com/jeanparpaillon/elixir-snmp#instrumenting-mib))
 is not enough to compile MIB files, and `.mib` files need to be already compiled
 into `*.bin` when compiling elixir code. So `:mib` compiler can be added in the
-list of compilers of the application (see https://github.com/jeanparpaillon/elixir-snmp/blob/master/lib/mix/tasks/compile.mib.ex).
-
-See related config options
-  [here](https://github.com/jeanparpaillon/elixir-snmp/blob/4c37a2d511917bf99029625844666b8ab0f5ac0c/lib/snmp/compiler/options.ex#L3-L4).
+list of compilers of the application (see [compile.mib.ex](https://github.com/jeanparpaillon/elixir-snmp/blob/master/lib/mix/tasks/compile.mib.ex)).
 
 ### Instrumenting MIB
 * As noted below in [Defining Agent](https://github.com/jeanparpaillon/elixir-snmp#defining-agent), there are two mandatory SNMP mibs. You
@@ -54,9 +51,9 @@ defmodule MyApp.Mib.Standard do
   use Snmp.Mib.Standard,
     otp_app: :my_app,
     conf: [
-      sysObjectID: ,
-      snmpEnableAuthenTraps: ,
-      sysServices: []
+      sysObjectID: [integer()],
+      snmpEnableAuthenTraps: :enabled | :disabled,
+      sysServices: integer()
     ]
 end
 ```
@@ -66,11 +63,8 @@ defmodule MyApp.Mib.Framework do
   use Snmp.Mib.Framework,
    otp_app: :my_app,
    conf: [
-     snmpEngineID: ,
-     snmpEngineMaxMessageSize: ,
-     sysObjectID: ,
-     sysServices: ,
-     snmpEnableAuthenTraps:
+     snmpEngineID: [integer()],
+     snmpEngineMaxMessageSize: integer(),
    ]
 end
 ```

--- a/lib/snmp/mib/user_based_sm.ex
+++ b/lib/snmp/mib/user_based_sm.ex
@@ -48,7 +48,7 @@ defmodule Snmp.Mib.UserBasedSm do
       access
       |> Vacm.vacmAccess(:sec_level)
       |> case do
-        :noPrivNoAuth ->
+        :noAuthNoPriv ->
           {:usmNoAuthProtocol, '', :usmNoPrivProtocol, ''}
 
         :authNoPriv ->


### PR DESCRIPTION
### Summary of Change
- FIx typo in[ lib/snmp/mib/user_based_sm.ex](https://github.com/jeanparpaillon/elixir-snmp/compare/master...mattjg908:update_security_level?expand=1#diff-b05db05a661f69a198283be4d68a3b93d697e9af270d016bb8f51ff0a4da734aR51), `s/noPrivNoAuth/noAuthNoPriv/` 
- Fix/update README

### Reason for Change

When updating an Agent and trying to allow for `noAuthNoPriv`, an error was thrown because the [library only accepts](https://github.com/jeanparpaillon/elixir-snmp/blob/master/lib/snmp/mib/user_based_sm.ex#L51) `noPrivNoAuth`, `authNoPriv`, and `authPriv`. This is problematic because OTP later reads this value when compiling, and `noPrivNoAuth` is not a valid security level so then an error is thrown.

I'm not sure what the authorative source is for SNMP information is, but http://www.snmp.com/snmpv3/snmpv3_intro.shtml does list `noAuthNoPriv`, as well as other places in the elixir-snmp library ([Snmp.Agent](https://github.com/jeanparpaillon/elixir-snmp/blob/master/lib/snmp/agent.ex#L46), [README](https://github.com/jeanparpaillon/elixir-snmp/blob/master/README.md#defining-agent)).

#### Before I (use `noAuthNoPriv` in agent)
![1](https://user-images.githubusercontent.com/3199675/137997145-c4ecd364-2917-47c3-b2e4-0147ffc2ed08.png)

#### Before II (use `noPrivNoAuth` in agent)
![2](https://user-images.githubusercontent.com/3199675/137997122-caf317c8-2178-4d3f-a947-1e95c23f293b.png)

#### After (successful `iex -S mix`, use `noAuthNoPriv` in agent)
![after](https://user-images.githubusercontent.com/3199675/137997180-29366f1c-4aff-4bf6-b074-1447ddde1208.png)
